### PR TITLE
BoxController 테스트 케이스 작성 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -39,3 +39,6 @@ out/
 ### properties ###
 application.properties
 application.yml
+
+### Qclass Intellij ###
+/src/main/generated/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -65,6 +65,6 @@ dependencies {
 	implementation'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/backend/src/test/java/kr/guards/memorybox/domain/box/controller/BoxControllerTest.java
+++ b/backend/src/test/java/kr/guards/memorybox/domain/box/controller/BoxControllerTest.java
@@ -1,0 +1,63 @@
+package kr.guards.memorybox.domain.box.controller;
+
+import kr.guards.memorybox.domain.box.service.BoxService;
+import kr.guards.memorybox.domain.box.service.BoxServiceImpl;
+import kr.guards.memorybox.utils.MockAuthentication;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.security.Principal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@ExtendWith(MockitoExtension.class)
+public class BoxControllerTest {
+    MockMvc mockMvc;
+
+    // @InjectMocks와 @Mock이 먹히지 않아서 Mock을 직접 주입해서 사용하니 되더라... 왜냐구 ㅠㅠㅠ
+    BoxService boxService = mock(BoxServiceImpl.class);
+    BoxController boxController = new BoxController(boxService);
+    MockAuthentication authentication = new MockAuthentication();
+
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(boxController).build();
+    }
+
+    @Nested
+    @DisplayName("기억함 열기")
+    public class unLockBox {
+        @Test
+        @DisplayName("상태로 변경 성공하여 200 리턴")
+        public void unLockBoxSuccess() throws Exception {
+            when(boxService.unlockBox("123123", 1L)).thenReturn(true);
+
+            mockMvc.perform(put("/api/box/unlock/{boxId}", "123123")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .principal((Principal) authentication.getPrincipal()))
+                    .andDo(print())
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+        }
+
+        @Test
+        @DisplayName("상태로 변경 중 오류 발생하여 404 리턴")
+        public void unLockBoxFailed() throws Exception {
+            when(boxService.unlockBox("123123", 1L)).thenReturn(false);
+
+            mockMvc.perform(put("/api/box/unlock/{boxId}", "123123")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .principal((Principal) authentication.getPrincipal()))
+                    .andDo(print())
+                    .andExpect(MockMvcResultMatchers.status().isNotFound());
+        }
+    }
+}

--- a/backend/src/test/java/kr/guards/memorybox/domain/box/service/BoxServiceTest.java
+++ b/backend/src/test/java/kr/guards/memorybox/domain/box/service/BoxServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.time.LocalDateTime;
 
@@ -27,18 +28,12 @@ class BoxServiceTest {
     @Test
     @DisplayName("Box Create Success")
     void createBoxSuccess() {
+        /*
+        기억함 생성 시 제대로 BoxId를 return 하는지 체크
+        또한 box 를 저장하는 호출이 한 번만 실행되었는지 확인함.
+         */
+
         BoxCreatePostReq boxCreatePostReq = new BoxCreatePostReq("테스트 기억함", "테스트 기억함 입니다", LocalDateTime.now().plusDays(1), false, null, 0, 0, null);
-
-        Box box = Box.builder()
-                .boxId("tESt1234")
-                .boxName(boxCreatePostReq.getBoxName())
-                .boxDescription(boxCreatePostReq.getBoxDescription())
-                .boxOpenAt(boxCreatePostReq.getBoxOpenAt())
-                .boxIsSolo(boxCreatePostReq.isBoxIsSolo())
-                .userSeq(1L)
-                .build();
-
-        when(boxRepository.save(any(Box.class))).thenReturn(box);
 
         // when
         String result = boxService.boxCreate(boxCreatePostReq, 1L);
@@ -53,6 +48,10 @@ class BoxServiceTest {
     @Test
     @DisplayName("Box Create Fail")
     void createBoxFail() {
+        /*
+        기억함 생성 중에 오류가 발생했을 경우에 대한 테스트
+         */
+        
         String result = "";
         try {
             when(boxRepository.save(any(Box.class))).thenThrow(new Exception());

--- a/backend/src/test/java/kr/guards/memorybox/domain/box/service/BoxServiceTest.java
+++ b/backend/src/test/java/kr/guards/memorybox/domain/box/service/BoxServiceTest.java
@@ -4,6 +4,7 @@ import kr.guards.memorybox.domain.box.db.entity.Box;
 import kr.guards.memorybox.domain.box.db.repository.BoxRepository;
 import kr.guards.memorybox.domain.box.request.BoxCreatePostReq;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,42 +25,47 @@ class BoxServiceTest {
 
     @Mock
     BoxRepository boxRepository;
-
-    @Test
-    @DisplayName("Box Create Success")
-    void createBoxSuccess() {
+    
+    @Nested
+    @DisplayName("기억함 생성")
+    public class CreateBox {
+        @Test
+        @DisplayName("성공")
+        void createBoxSuccess() {
         /*
         기억함 생성 시 제대로 BoxId를 return 하는지 체크
         또한 box 를 저장하는 호출이 한 번만 실행되었는지 확인함.
          */
 
-        BoxCreatePostReq boxCreatePostReq = new BoxCreatePostReq("테스트 기억함", "테스트 기억함 입니다", LocalDateTime.now().plusDays(1), false, null, 0, 0, null);
+            BoxCreatePostReq boxCreatePostReq = new BoxCreatePostReq("테스트 기억함", "테스트 기억함 입니다", LocalDateTime.now().plusDays(1), false, null, 0, 0, null);
 
-        // when
-        String result = boxService.boxCreate(boxCreatePostReq, 1L);
+            // when
+            String result = boxService.boxCreate(boxCreatePostReq, 1L);
+            System.out.println("생성된 기억함 번호 : " + result);
 
-        // then
-        assertThat(result).isNotNull();
+            // then
+            assertThat(result).isNotNull();
 
-        // verify
-        verify(boxRepository, times(1)).save(any(Box.class));
-    }
+            // verify
+            verify(boxRepository, times(1)).save(any(Box.class));
+        }
 
-    @Test
-    @DisplayName("Box Create Fail")
-    void createBoxFail() {
+        @Test
+        @DisplayName("실패")
+        void createBoxFail() {
         /*
         기억함 생성 중에 오류가 발생했을 경우에 대한 테스트
          */
-        
-        String result = "";
-        try {
-            when(boxRepository.save(any(Box.class))).thenThrow(new Exception());
-        } catch (Exception e) {
-            System.out.println("기억함 저장 중 오류 발생");
-            result = null;
+
+            String result = "";
+            try {
+                when(boxRepository.save(any(Box.class))).thenThrow(new Exception());
+            } catch (Exception e) {
+                System.out.println("기억함 저장 중 오류 발생");
+                result = null;
+            }
+            // then
+            assertThat(result).isNull();
         }
-        // then
-        assertThat(result).isNull();
     }
 }

--- a/backend/src/test/java/kr/guards/memorybox/utils/MockAuthentication.java
+++ b/backend/src/test/java/kr/guards/memorybox/utils/MockAuthentication.java
@@ -1,0 +1,56 @@
+package kr.guards.memorybox.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.security.Principal;
+import java.util.Collection;
+
+/**
+ * 유저 번호 1번으로 임시 인증 권한을 생성하는 객체
+ */
+public class MockAuthentication implements Authentication {
+    public MockAuthentication() {
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        Principal principal = new Principal() {
+            @Override
+            public String getName() {
+                return "1";
+            }
+        };
+        return principal;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}


### PR DESCRIPTION
지난번에 실패한 Controller 부분에 대한 테스트 케이스를 작성
실패 이유는 Spring Security에서 사용하는 Principal 객체의 부재였었는데,
해당 내용에 대해 공부하면서 객체를 테스트용으로 생성해서 사용하면 되겠다고 생각하여 UserSeq 1에 해당하는 Principal을 작성하여 사용하여 성공.

간단하게 테스트가 가능한 PUT /api/box/unlock 부분을
Junit5 의 Nested 를 적용하여 기억함 열기에 대한 테스트 케이스를 작성함.

POST 테스트는 아직 시도 중.
